### PR TITLE
Reduce mutex contention for high device count scenarios

### DIFF
--- a/internal/tunnel/remoted.go
+++ b/internal/tunnel/remoted.go
@@ -11,8 +11,11 @@ import (
 
 type RemotedService struct {
 	mu           sync.Mutex
+	cond         *sync.Cond
 	suspendCount int
 	isSuspended  bool
+	suspending   bool // true while suspend exec.Command is in progress
+	resuming     bool // true while resume exec.Command is in progress
 }
 
 var (
@@ -23,6 +26,7 @@ var (
 func SuspendRemoted() (func(), error) {
 	once.Do(func() {
 		instance = &RemotedService{}
+		instance.cond = sync.NewCond(&instance.mu)
 	})
 
 	return instance.suspendRemoted()
@@ -39,18 +43,36 @@ func ForceResumeRemoted() error {
 
 func (r *RemotedService) forceResume() error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
+
+	// Wait if someone else is currently suspending or resuming
+	for r.suspending || r.resuming {
+		r.cond.Wait()
+	}
 
 	if !r.isSuspended {
+		r.mu.Unlock()
 		return nil
 	}
 
-	if err := signalRemotedResume(); err != nil {
+	// We need to resume - mark that we're resuming and release the mutex
+	r.resuming = true
+	r.mu.Unlock()
+
+	// Perform the actual resume action without holding the mutex
+	err := signalRemotedResume()
+
+	r.mu.Lock()
+	r.resuming = false
+	if err != nil {
+		r.cond.Broadcast()
+		r.mu.Unlock()
 		return err
 	}
 
 	r.isSuspended = false
 	r.suspendCount = 0
+	r.cond.Broadcast()
+	r.mu.Unlock()
 
 	return nil
 }
@@ -63,36 +85,79 @@ func (r *RemotedService) suspendRemoted() (func(), error) {
 	}
 
 	r.mu.Lock()
-	if r.suspendCount == 0 && !r.isSuspended {
-		// Perform the actual suspend action here
-		if err := signalRemotedSuspend(); err != nil {
-			return nil, fmt.Errorf("failed to suspend remoted: %v", err)
-		}
 
-		r.isSuspended = true
-	} else {
-		log.Trace("Remoted service is already suspended; current count:", r.suspendCount+1)
+	// Wait if someone else is currently suspending or resuming
+	for r.suspending || r.resuming {
+		r.cond.Wait()
 	}
-	r.suspendCount++
+
+	// If already suspended, just increment count and return
+	if r.isSuspended {
+		r.suspendCount++
+		log.Trace("Remoted service is already suspended; current count:", r.suspendCount)
+		r.mu.Unlock()
+		return r.createResumeFunc(), nil
+	}
+
+	// We need to suspend - mark that we're suspending and release the mutex
+	r.suspending = true
 	r.mu.Unlock()
 
+	// Perform the actual suspend action without holding the mutex
+	err := signalRemotedSuspend()
+
+	r.mu.Lock()
+	r.suspending = false
+	if err != nil {
+		r.cond.Broadcast() // Wake up any waiters so they can try
+		r.mu.Unlock()
+		return nil, fmt.Errorf("failed to suspend remoted: %v", err)
+	}
+
+	r.isSuspended = true
+	r.suspendCount++
+	r.cond.Broadcast() // Wake up any waiters
+	r.mu.Unlock()
+
+	return r.createResumeFunc(), nil
+}
+
+// createResumeFunc returns a function that decrements the suspend count
+// and resumes remoted when the count reaches zero.
+func (r *RemotedService) createResumeFunc() func() {
 	return func() {
 		r.mu.Lock()
-		defer r.mu.Unlock()
+
+		// Wait if someone else is currently suspending or resuming
+		for r.suspending || r.resuming {
+			r.cond.Wait()
+		}
 
 		if r.suspendCount > 0 {
-			log.Trace("Not resuming remoted service; current count:", r.suspendCount-1)
 			r.suspendCount--
+			log.Trace("Decremented suspend count; current count:", r.suspendCount)
 		}
 
 		if r.suspendCount == 0 && r.isSuspended {
-			if err := signalRemotedResume(); err != nil {
-				return
-			}
+			// We need to resume - mark that we're resuming and release the mutex
+			r.resuming = true
+			r.mu.Unlock()
 
-			r.isSuspended = false
+			// Perform the actual resume action without holding the mutex
+			err := signalRemotedResume()
+
+			r.mu.Lock()
+			r.resuming = false
+			if err == nil {
+				r.isSuspended = false
+			}
+			r.cond.Broadcast() // Wake up any waiters
+			r.mu.Unlock()
+			return
 		}
-	}, nil
+
+		r.mu.Unlock()
+	}
 }
 
 // SuspendRemoted sends a SIGSTOP signal to all processes named "remoted"


### PR DESCRIPTION
- RemotedService: Release mutex before blocking exec.Command calls, use condition variable to coordinate concurrent callers
- API service: Use RWMutex for rsdMap and tunnels to allow concurrent reads without blocking writes
- Fix data races in /tunnel/ and /services/ endpoints (missing locks)
- Make retry delays cancellable and stop retrying when device disconnects