### PR TITLE
Cache RSD services during device discovery to avoid redundant connections

### DIFF
--- a/internal/rsd/types.go
+++ b/internal/rsd/types.go
@@ -12,6 +12,12 @@ type RsdService struct {
 	InterfaceName    string
 	Address          string
 	DeviceIosVersion string
+	Services         map[string]ServiceEntry
+}
+
+// ServiceEntry represents a service available on the device.
+type ServiceEntry struct {
+	Port uint32
 }
 
 type RsdServiceEvent struct {

--- a/internal/tunnel/rsd.go
+++ b/internal/tunnel/rsd.go
@@ -160,46 +160,36 @@ func (r RsdHandshakeResponse) GetServices() map[string]RsdServiceEntry {
 	return r.Services
 }
 
-// NewWithAddrPort creates a new RsdService with the given address and port 58783 using a HTTP2 based XPC connection,
-// connecting to an operating system level TUN device. The deviceId is used for logging (UDID or address).
-func NewWithAddrPort(addr string, port int, deviceId string) (RsdService, error) {
-	l := log.WithField("device", deviceId)
-	l.Trace("NewWithAddrPort: connecting to RSD port")
+// NewWithAddrPort creates a new RsdService with the given address and port using a HTTP2 based XPC connection,
+// connecting to an operating system level TUN device.
+func NewWithAddrPort(addr string, port int) (RsdService, error) {
 	conn, err := ConnectTUN(addr, port)
 	if err != nil {
 		return RsdService{}, fmt.Errorf("NewWithAddrPort: failed to connect to device: %w", err)
 	}
-	l.Trace("NewWithAddrPort: TCP connection established")
-	return newRsdServiceFromTcpConn(conn, deviceId)
+	return newRsdServiceFromTcpConn(conn)
 }
 
 // NewWithAddr creates a new RsdService with the given address and port 58783 using a HTTP2 based XPC connection.
-func NewWithAddr(addr string, udid string) (RsdService, error) {
-	l := log.WithField("udid", udid)
-	l.Trace("NewWithAddr: connecting to RSD port")
+func NewWithAddr(addr string) (RsdService, error) {
 	conn, err := ConnectTUN(addr, RSD_PORT)
 	if err != nil {
 		return RsdService{}, fmt.Errorf("NewWithAddr: failed to connect to device: %w", err)
 	}
-	l.Trace("NewWithAddr: TCP connection established")
-	return newRsdServiceFromTcpConn(conn, udid)
+	return newRsdServiceFromTcpConn(conn)
 }
 
-func newRsdServiceFromTcpConn(conn *net.TCPConn, udid string) (RsdService, error) {
-	l := log.WithField("udid", udid)
-	l.Trace("newRsdServiceFromTcpConn: creating HTTP/2 connection")
+func newRsdServiceFromTcpConn(conn *net.TCPConn) (RsdService, error) {
 	h, err := http.NewHttpConnection(conn)
 	if err != nil {
 		return RsdService{}, fmt.Errorf("newRsdServiceFromTcpConn: failed to connect to http2: %w", err)
 	}
 
-	l.Trace("newRsdServiceFromTcpConn: creating XPC connection")
 	x, err := CreateXpcConnection(h)
 	if err != nil {
 		return RsdService{}, fmt.Errorf("newRsdServiceFromTcpConn: failed to create xpc connection: %w", err)
 	}
 
-	l.Trace("newRsdServiceFromTcpConn: complete")
 	return RsdService{
 		xpc: x,
 		c:   h,

--- a/internal/tunnel/untrusted.go
+++ b/internal/tunnel/untrusted.go
@@ -22,9 +22,9 @@ import (
 	"golang.org/x/crypto/hkdf"
 )
 
-// untrustedTunnelServiceName is the service name that is described in the Remote Service Discovery of the
+// UntrustedTunnelServiceName is the service name that is described in the Remote Service Discovery of the
 // ethernet interface of the device (not the tunnel interface)
-const untrustedTunnelServiceName = "com.apple.internal.dt.coredevice.untrusted.tunnelservice"
+const UntrustedTunnelServiceName = "com.apple.internal.dt.coredevice.untrusted.tunnelservice"
 
 type PairingResult struct {
 	SharedSecret []byte

--- a/internal/tunnelmgr/device.go
+++ b/internal/tunnelmgr/device.go
@@ -340,7 +340,7 @@ func (d *TunnelDevice) ensurePaired(ctx context.Context) error {
 			return nil
 		}
 
-		err := tunnel.ManualPair(ctx, d.pm, d.rsdInfo.Address, d.udid, d.tn)
+		err := tunnel.ManualPair(ctx, d.pm, d.rsdInfo.Address, d.udid, d.getUntrustedTunnelPort(), d.tn)
 		if err == nil {
 			log.WithField("udid", d.udid).Debug("Device is paired")
 			return nil
@@ -388,7 +388,7 @@ func (d *TunnelDevice) connectTunnel(ctx context.Context) (*tunnel.Tunnel, error
 		attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
 
 		// autoPair=false since we already ensured pairing in phase 1
-		t, err = tunnel.ManualPairAndConnectToTunnel(attemptCtx, d.pm, d.rsdInfo.Address, d.udid, false, d.tn)
+		t, err = tunnel.ManualPairAndConnectToTunnel(attemptCtx, d.pm, d.rsdInfo.Address, d.udid, d.getUntrustedTunnelPort(), false, d.tn)
 		cancel()
 
 		if err == nil {
@@ -485,4 +485,13 @@ func (d *TunnelDevice) isIos17OrGreater() bool {
 	}
 
 	return true
+}
+
+// getUntrustedTunnelPort returns the port for the untrusted tunnel service from the discovered services.
+// Returns 0 if the service is not found.
+func (d *TunnelDevice) getUntrustedTunnelPort() int {
+	if entry, ok := d.rsdInfo.Services[tunnel.UntrustedTunnelServiceName]; ok {
+		return int(entry.Port)
+	}
+	return 0
 }


### PR DESCRIPTION
  - Extend RsdService to include Services map from initial discovery
  - Pass untrusted tunnel port to ManualPair/ManualPairAndConnectToTunnel
  - Remove getUntrustedTunnelServicePort which performed a second RSD handshake
  - Simplify RSD connection functions by removing unused deviceId parameters
  - Export UntrustedTunnelServiceName constant for use in tunnelmgr